### PR TITLE
Exclusively build for pwdata and filter out modules 

### DIFF
--- a/pycg/__main__.py
+++ b/pycg/__main__.py
@@ -13,6 +13,10 @@ def main():
         "--package", help="Package containing the code to be analyzed", default=None
     )
     parser.add_argument(
+        "--exclusives", help="Exclusive package to analyze", default=[])
+    parser.add_argument(
+        "--ignored-mods", help="Modules to ignore during traversal", default=[])
+    parser.add_argument(
         "--fasten",
         help="Produce call graph using the FASTEN format",
         action="store_true",
@@ -57,7 +61,9 @@ def main():
     args = parser.parse_args()
 
     cg = CallGraphGenerator(
-        args.entry_point, args.package, args.max_iter, args.operation
+        args.entry_point, args.package,
+        args.exclusives, args.ignored_mods,
+        args.max_iter, args.operation
     )
     cg.analyze()
 

--- a/pycg/__main__.py
+++ b/pycg/__main__.py
@@ -62,7 +62,7 @@ def main():
 
     cg = CallGraphGenerator(
         args.entry_point, args.package,
-        args.exclusives, args.ignored_mods,
+        args.exclusives, args.skip_classes,
         args.max_iter, args.operation
     )
     cg.analyze()

--- a/pycg/__main__.py
+++ b/pycg/__main__.py
@@ -15,7 +15,7 @@ def main():
     parser.add_argument(
         "--exclusives", help="Exclusive package to analyze", default=[])
     parser.add_argument(
-        "--ignored-mods", help="Modules to ignore during traversal", default=[])
+        "--skip-classes", help="Classes to skip during traversal", default=[])
     parser.add_argument(
         "--fasten",
         help="Produce call graph using the FASTEN format",

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -187,7 +187,9 @@ class PostProcessor(ProcessingBase):
             cls = self.class_manager.create(cls_def.get_ns(), self.modname)
 
         cls.clear_mro()
+        print('base node', node)
         for base in node.bases:
+            print('base', base)
             # all bases are of the type ast.Name
             self.visit(base)
 

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -185,7 +185,7 @@ class PostProcessor(ProcessingBase):
         cls = self.class_manager.get(cls_def.get_ns())
         if not cls:
             cls = self.class_manager.create(cls_def.get_ns(), self.modname)
-
+        print(cls.__name__)
         cls.clear_mro()
         for base in node.bases:
             # all bases are of the type ast.Name

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -185,7 +185,7 @@ class PostProcessor(ProcessingBase):
         cls = self.class_manager.get(cls_def.get_ns())
         if not cls:
             cls = self.class_manager.create(cls_def.get_ns(), self.modname)
-        print(cls.__name__)
+        print(cls)
         cls.clear_mro()
         for base in node.bases:
             # all bases are of the type ast.Name

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -189,11 +189,11 @@ class PostProcessor(ProcessingBase):
         cls.clear_mro()
         print('base node', node)
         for base in node.bases:
-            print('base', base)
             # all bases are of the type ast.Name
             self.visit(base)
 
             bases = self.decode_node(base)
+            print('bases', bases)
             for base_def in bases:
                 if not isinstance(base_def, Definition):
                     continue

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -178,9 +178,7 @@ class PostProcessor(ProcessingBase):
         super().visit_FunctionDef(node)
 
     def visit_ClassDef(self, node):
-        print('post visit', node.name)
         if node.name in self.ignored_mods:
-            print('skip')
             return
         # create a definition for the class (node.name)
         cls_def = self.def_manager.handle_class_def(self.current_ns, node.name)

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -185,7 +185,7 @@ class PostProcessor(ProcessingBase):
         cls = self.class_manager.get(cls_def.get_ns())
         if not cls:
             cls = self.class_manager.create(cls_def.get_ns(), self.modname)
-        print(cls)
+        print(cls_def, node.name, node.bases)
         cls.clear_mro()
         for base in node.bases:
             # all bases are of the type ast.Name

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -178,6 +178,10 @@ class PostProcessor(ProcessingBase):
         super().visit_FunctionDef(node)
 
     def visit_ClassDef(self, node):
+        print('post visit', node.name)
+        if node.name in self.ignored_mods:
+            print('skip')
+            return
         # create a definition for the class (node.name)
         cls_def = self.def_manager.handle_class_def(self.current_ns, node.name)
 
@@ -185,7 +189,6 @@ class PostProcessor(ProcessingBase):
         cls = self.class_manager.get(cls_def.get_ns())
         if not cls:
             cls = self.class_manager.create(cls_def.get_ns(), self.modname)
-        print(cls_def, node.name, node.bases)
         cls.clear_mro()
         for base in node.bases:
             # all bases are of the type ast.Name

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -30,6 +30,8 @@ class PostProcessor(ProcessingBase):
         self,
         input_file,
         modname,
+        exclusives,
+        ignored_mods,
         import_manager,
         scope_manager,
         def_manager,
@@ -38,6 +40,8 @@ class PostProcessor(ProcessingBase):
         modules_analyzed=None,
     ):
         super().__init__(input_file, modname, modules_analyzed)
+        self.exclusives = exclusives
+        self.ignored_mods = ignored_mods
         self.import_manager = import_manager
         self.scope_manager = scope_manager
         self.def_manager = def_manager
@@ -329,6 +333,8 @@ class PostProcessor(ProcessingBase):
     def analyze_submodules(self):
         super().analyze_submodules(
             PostProcessor,
+            self.exclusives,
+            self.ignored_mods,
             self.import_manager,
             self.scope_manager,
             self.def_manager,

--- a/pycg/processing/postprocessor.py
+++ b/pycg/processing/postprocessor.py
@@ -187,13 +187,11 @@ class PostProcessor(ProcessingBase):
             cls = self.class_manager.create(cls_def.get_ns(), self.modname)
 
         cls.clear_mro()
-        print('base node', node)
         for base in node.bases:
             # all bases are of the type ast.Name
             self.visit(base)
 
             bases = self.decode_node(base)
-            print('bases', bases)
             for base_def in bases:
                 if not isinstance(base_def, Definition):
                     continue

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -91,7 +91,7 @@ class PreProcessor(ProcessingBase):
                 i for i in items if not \
                     any(ignored_mod in i for ignored_mod in self.ignored_mods)
             ]
-
+            print('items',items)
             for item in items:
                 defi = self.def_manager.get(item)
                 if not defi:

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -219,8 +219,8 @@ class PreProcessor(ProcessingBase):
             tgt_name = import_item.asname if import_item.asname else import_item.name
             imported_name = self.import_manager.handle_import(src_name, level)
 
-            # Limit to exclusive module
-            if src_name.split(".")[0] not in self.exclusives:
+            # Limit to exclusive module if exclusives exist
+            if len(self.exclusives) > 0 and src_name.split(".")[0] not in self.exclusives:
                 continue
 
             # Skip ignored modules

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -210,12 +210,12 @@ class PreProcessor(ProcessingBase):
             src_name = handle_src_name(import_item.name)
             tgt_name = import_item.asname if import_item.asname else import_item.name
             imported_name = self.import_manager.handle_import(src_name, level)
-            
-            # Limit to exclusive module            
+
+            # Limit to exclusive module
             if src_name.split(".")[0] not in self.exclusives:
                 continue
 
-            # Skip ignored modules            
+            # Skip ignored modules
             if tgt_name in self.ignored_mods:
                 continue
 

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -32,7 +32,7 @@ class PreProcessor(ProcessingBase):
         filename,
         modname,
         exclusives,
-        ignored_mods,
+        skip_classes,
         import_manager,
         scope_manager,
         def_manager,
@@ -44,7 +44,7 @@ class PreProcessor(ProcessingBase):
 
         self.modname = modname
         self.exclusives = exclusives
-        self.ignored_mods = ignored_mods
+        self.skip_classes = skip_classes
         self.mod_dir = "/".join(self.filename.split("/")[:-1])
 
         self.import_manager = import_manager
@@ -53,7 +53,7 @@ class PreProcessor(ProcessingBase):
         self.class_manager = class_manager
         self.module_manager = module_manager
 
-        self.ignored_mod_pattern = re.compile('|'.join(map(re.escape, self.ignored_mods)))
+        self.skip_classes_pattern = re.compile('|'.join(map(re.escape, self.skip_classes)))
 
     def _get_fun_defaults(self, node):
         defaults = {}
@@ -79,7 +79,7 @@ class PreProcessor(ProcessingBase):
             PreProcessor,
             modname,
             self.exclusives,
-            self.ignored_mods,
+            self.skip_classes,
             self.import_manager,
             self.scope_manager,
             self.def_manager,
@@ -92,7 +92,7 @@ class PreProcessor(ProcessingBase):
         def iterate_mod_items(items, const):
             items = [
                 item for item in items 
-                if not self.ignored_mod_pattern.search(item)
+                if not self.skip_classes_pattern.search(item)
             ]
             
             for item in items:
@@ -222,8 +222,8 @@ class PreProcessor(ProcessingBase):
             if self.exclusives and src_name.split(".")[0] not in self.exclusives:
                 continue
 
-            # Skip ignored modules
-            if tgt_name in self.ignored_mods:
+            # Skip specified classes
+            if tgt_name in self.skip_classes:
                 continue
 
             imported_name = self.import_manager.handle_import(src_name, level)
@@ -428,7 +428,7 @@ class PreProcessor(ProcessingBase):
 
     def visit_ClassDef(self, node):
         # create a definition for the class (node.name)
-        if node.name in self.ignored_mods:
+        if node.name in self.skip_classes:
             return
 
         cls_def = self.def_manager.handle_class_def(self.current_ns, node.name)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -211,8 +211,6 @@ class PreProcessor(ProcessingBase):
                 tgt_defi.get_name_pointer().add(defi.get_ns())
                 scope.add_def(target, tgt_defi)
 
-        print([*node.names], self.modname)
-
         for import_item in node.names:
             src_name = handle_src_name(import_item.name)
             tgt_name = import_item.asname if import_item.asname else import_item.name

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -206,36 +206,39 @@ class PreProcessor(ProcessingBase):
                 tgt_defi.get_name_pointer().add(defi.get_ns())
                 scope.add_def(target, tgt_defi)
 
-        # Limit to exclusive module
-        print()
-        if node.module in self.exclusives:
-            for import_item in node.names:
-                src_name = handle_src_name(import_item.name)
-                tgt_name = import_item.asname if import_item.asname else import_item.name
-                imported_name = self.import_manager.handle_import(src_name, level)
+        print('node', node)
+        for import_item in node.names:
+            src_name = handle_src_name(import_item.name)
+            tgt_name = import_item.asname if import_item.asname else import_item.name
+            imported_name = self.import_manager.handle_import(src_name, level)
 
-                # Skip ignored modules
-                if tgt_name in self.ignored_mods:
-                    continue
+            # Limit to exclusive module
+            if src_name.split(".")[0] not in self.exclusives:
+                continue
 
-                if not imported_name:
-                    add_external_def(src_name, tgt_name)
-                    continue
+            # Skip ignored modules
+            if tgt_name in self.ignored_mods:
+                continue
 
-                fname = self.import_manager.get_filepath(imported_name)
-                if not fname:
-                    add_external_def(src_name, tgt_name)
-                    continue
-                # only analyze modules under the current directory
-                if self.import_manager.get_mod_dir() in fname:
-                    if imported_name not in self.modules_analyzed:
-                        self.analyze_submodule(imported_name)
-                    handle_scopes(import_item.name, tgt_name, imported_name)
-                else:
-                    add_external_def(src_name, tgt_name)
+            if not imported_name:
+                add_external_def(src_name, tgt_name)
+                continue
+
+            fname = self.import_manager.get_filepath(imported_name)
+            if not fname:
+                add_external_def(src_name, tgt_name)
+                continue
+            # only analyze modules under the current directory
+            if self.import_manager.get_mod_dir() in fname:
+                if imported_name not in self.modules_analyzed:
+                    self.analyze_submodule(imported_name)
+                handle_scopes(import_item.name, tgt_name, imported_name)
+            else:
+                add_external_def(src_name, tgt_name)
 
         # handle all modules that were not analyzed
         for modname in self.import_manager.get_imports(self.modname):
+            print('mod', mod)
             fname = self.import_manager.get_filepath(modname)
 
             if not fname:

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -214,13 +214,15 @@ class PreProcessor(ProcessingBase):
                 tgt_defi.get_name_pointer().add(defi.get_ns())
                 scope.add_def(target, tgt_defi)
 
+        print(node.names, self.modname)
+
         for import_item in node.names:
             src_name = handle_src_name(import_item.name)
             tgt_name = import_item.asname if import_item.asname else import_item.name
             imported_name = self.import_manager.handle_import(src_name, level)
 
             # Limit to exclusive module if exclusives exist
-            if len(self.exclusives) > 0 and src_name.split(".")[0] not in self.exclusives:
+            if self.exclusives and src_name.split(".")[0] not in self.exclusives:
                 continue
 
             # Skip ignored modules
@@ -245,7 +247,7 @@ class PreProcessor(ProcessingBase):
 
         # handle all modules that were not analyzed
         for modname in self.import_manager.get_imports(self.modname):
-            if modname.split(".")[0] not in self.exclusives:
+            if self.exclusives and modname.split(".")[0] not in self.exclusives:
                 continue
 
             fname = self.import_manager.get_filepath(modname)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -206,14 +206,14 @@ class PreProcessor(ProcessingBase):
                 tgt_defi.get_name_pointer().add(defi.get_ns())
                 scope.add_def(target, tgt_defi)
 
+        # Limit to exclusive module
+        if node.module not in self.exclusives:
+            return
+        
         for import_item in node.names:
             src_name = handle_src_name(import_item.name)
             tgt_name = import_item.asname if import_item.asname else import_item.name
             imported_name = self.import_manager.handle_import(src_name, level)
-
-            # Limit to exclusive module
-            if src_name.split(".")[0] not in self.exclusives:
-                continue
 
             # Skip ignored modules
             if tgt_name in self.ignored_mods:

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -113,6 +113,7 @@ class PreProcessor(ProcessingBase):
             items = self.scope_manager.handle_module(
                 self.modname, self.filename, self.contents
             )
+            print('pre items', items)
 
             root_sc = self.scope_manager.get_scope(self.modname)
             root_defi = self.def_manager.get(self.modname)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -237,8 +237,10 @@ class PreProcessor(ProcessingBase):
                 add_external_def(src_name, tgt_name)
 
         # handle all modules that were not analyzed
-        print('mod full', self.modname)
         for modname in self.import_manager.get_imports(self.modname):
+            if modname.split(".")[0] not in self.exclusives:
+                continue
+            
             print('mod', modname)
             fname = self.import_manager.get_filepath(modname)
 

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -19,6 +19,7 @@
 # under the License.
 #
 import ast
+import re
 
 from pycg import utils
 from pycg.machinery.definitions import Definition
@@ -51,6 +52,8 @@ class PreProcessor(ProcessingBase):
         self.def_manager = def_manager
         self.class_manager = class_manager
         self.module_manager = module_manager
+
+        self.ignored_mod_pattern = re.compile('|'.join(map(re.escape, self.ignored_mods)))
 
     def _get_fun_defaults(self, node):
         defaults = {}
@@ -88,8 +91,8 @@ class PreProcessor(ProcessingBase):
     def visit_Module(self, node):
         def iterate_mod_items(items, const):
             items = [
-                i for i in items if \
-                    not any(ignored_mod in i for ignored_mod in self.ignored_mods)
+                item for item in items 
+                if not self.ignored_mod_pattern.search(item)
             ]
             
             for item in items:
@@ -224,6 +227,8 @@ class PreProcessor(ProcessingBase):
             if tgt_name in self.ignored_mods:
                 continue
 
+            print(tgt_name)
+
             if not imported_name:
                 add_external_def(src_name, tgt_name)
                 continue
@@ -244,6 +249,8 @@ class PreProcessor(ProcessingBase):
         for modname in self.import_manager.get_imports(self.modname):
             if self.exclusives and modname.split(".")[0] not in self.exclusives:
                 continue
+
+            print(modname)
 
             fname = self.import_manager.get_filepath(modname)
 

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -113,6 +113,10 @@ class PreProcessor(ProcessingBase):
             items = self.scope_manager.handle_module(
                 self.modname, self.filename, self.contents
             )
+            items = [
+                i for i in items if not \
+                    any(ignored_mod in i for ignored_mod in ignored_mods_set)
+            ]
             print('pre items', items)
 
             root_sc = self.scope_manager.get_scope(self.modname)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -237,8 +237,9 @@ class PreProcessor(ProcessingBase):
                 add_external_def(src_name, tgt_name)
 
         # handle all modules that were not analyzed
+        print('mod full', self.modname)
         for modname in self.import_manager.get_imports(self.modname):
-            print('mod', mod)
+            print('mod', modname)
             fname = self.import_manager.get_filepath(modname)
 
             if not fname:

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -87,7 +87,7 @@ class PreProcessor(ProcessingBase):
 
     def visit_Module(self, node):
         def iterate_mod_items(items, const):
-            print('iter items', items = [
+            print('iter items', [
                 i for i in items if \
                     any(ignored_mod in i for ignored_mod in self.ignored_mods)
             ])

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -207,33 +207,32 @@ class PreProcessor(ProcessingBase):
                 scope.add_def(target, tgt_defi)
 
         # Limit to exclusive module
-        if node.module not in self.exclusives:
-            return
-        
-        for import_item in node.names:
-            src_name = handle_src_name(import_item.name)
-            tgt_name = import_item.asname if import_item.asname else import_item.name
-            imported_name = self.import_manager.handle_import(src_name, level)
+        print()
+        if node.module in self.exclusives:
+            for import_item in node.names:
+                src_name = handle_src_name(import_item.name)
+                tgt_name = import_item.asname if import_item.asname else import_item.name
+                imported_name = self.import_manager.handle_import(src_name, level)
 
-            # Skip ignored modules
-            if tgt_name in self.ignored_mods:
-                continue
+                # Skip ignored modules
+                if tgt_name in self.ignored_mods:
+                    continue
 
-            if not imported_name:
-                add_external_def(src_name, tgt_name)
-                continue
+                if not imported_name:
+                    add_external_def(src_name, tgt_name)
+                    continue
 
-            fname = self.import_manager.get_filepath(imported_name)
-            if not fname:
-                add_external_def(src_name, tgt_name)
-                continue
-            # only analyze modules under the current directory
-            if self.import_manager.get_mod_dir() in fname:
-                if imported_name not in self.modules_analyzed:
-                    self.analyze_submodule(imported_name)
-                handle_scopes(import_item.name, tgt_name, imported_name)
-            else:
-                add_external_def(src_name, tgt_name)
+                fname = self.import_manager.get_filepath(imported_name)
+                if not fname:
+                    add_external_def(src_name, tgt_name)
+                    continue
+                # only analyze modules under the current directory
+                if self.import_manager.get_mod_dir() in fname:
+                    if imported_name not in self.modules_analyzed:
+                        self.analyze_submodule(imported_name)
+                    handle_scopes(import_item.name, tgt_name, imported_name)
+                else:
+                    add_external_def(src_name, tgt_name)
 
         # handle all modules that were not analyzed
         for modname in self.import_manager.get_imports(self.modname):

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -109,6 +109,8 @@ class PreProcessor(ProcessingBase):
 
         mod = self.module_manager.create(self.modname, self.filename)
 
+        print('visit_mod', self.modname,self.filename)
+
         first = 1
         last = len(self.contents.splitlines())
         if last == 0:
@@ -217,8 +219,7 @@ class PreProcessor(ProcessingBase):
         for import_item in node.names:
             src_name = handle_src_name(import_item.name)
             tgt_name = import_item.asname if import_item.asname else import_item.name
-            imported_name = self.import_manager.handle_import(src_name, level)
-
+            
             # Limit to exclusive module if exclusives exist
             if self.exclusives and src_name.split(".")[0] not in self.exclusives:
                 continue
@@ -227,6 +228,8 @@ class PreProcessor(ProcessingBase):
             if tgt_name in self.ignored_mods:
                 print('skip',tgt_name)
                 continue
+
+            imported_name = self.import_manager.handle_import(src_name, level)
 
             if not imported_name:
                 add_external_def(src_name, tgt_name)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -87,10 +87,13 @@ class PreProcessor(ProcessingBase):
 
     def visit_Module(self, node):
         def iterate_mod_items(items, const):
-            print('bad iter items', [
+            bad_items = [
                 i for i in items if \
                     any(ignored_mod in i for ignored_mod in self.ignored_mods)
-            ])
+            ]
+            if len(bad_items) > 0:
+                print('bad iter items', bad_items)
+
             for item in items:
                 defi = self.def_manager.get(item)
                 if not defi:
@@ -101,11 +104,6 @@ class PreProcessor(ProcessingBase):
                 parentns = ".".join(splitted[:-1])
                 self.scope_manager.get_scope(parentns).add_def(name, defi)
 
-        if "test_" in self.filename:
-            print('skip', self.filename)
-            return
-
-        print('modname', self.modname, self.filename)
         self.import_manager.set_current_mod(self.modname, self.filename)
 
         mod = self.module_manager.create(self.modname, self.filename)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -433,6 +433,11 @@ class PreProcessor(ProcessingBase):
 
     def visit_ClassDef(self, node):
         # create a definition for the class (node.name)
+        print('pre class', node.name)
+        if node.name in self.ignored_mods:
+            print('skip')
+            return
+
         cls_def = self.def_manager.handle_class_def(self.current_ns, node.name)
 
         mod = self.module_manager.get(self.modname)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -115,7 +115,7 @@ class PreProcessor(ProcessingBase):
             )
             items = [
                 i for i in items if not \
-                    any(ignored_mod in i for ignored_mod in ignored_mods_set)
+                    any(ignored_mod in i for ignored_mod in self.ignored_mods)
             ]
             print('pre items', items)
 

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -223,7 +223,10 @@ class PreProcessor(ProcessingBase):
             if self.exclusives and src_name.split(".")[0] not in self.exclusives:
                 continue
 
-            print('target',tgt_name)
+            # Skip ignored modules
+            if tgt_name in self.ignored_mods:
+                print('skip',tgt_name)
+                continue
 
             if not imported_name:
                 add_external_def(src_name, tgt_name)
@@ -245,6 +248,8 @@ class PreProcessor(ProcessingBase):
         for modname in self.import_manager.get_imports(self.modname):
             if self.exclusives and modname.split(".")[0] not in self.exclusives:
                 continue
+
+            print(modname)
 
             fname = self.import_manager.get_filepath(modname)
 

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -105,7 +105,9 @@ class PreProcessor(ProcessingBase):
                 parentns = ".".join(splitted[:-1])
                 self.scope_manager.get_scope(parentns).add_def(name, defi)
 
+        print('modname', self.modname, self.filename)
         self.import_manager.set_current_mod(self.modname, self.filename)
+        print('modname', self.modname, self.filename)
 
         mod = self.module_manager.create(self.modname, self.filename)
 

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -223,11 +223,7 @@ class PreProcessor(ProcessingBase):
             if self.exclusives and src_name.split(".")[0] not in self.exclusives:
                 continue
 
-            # Skip ignored modules
-            if tgt_name in self.ignored_mods:
-                continue
-
-            print(tgt_name)
+            print('target',tgt_name)
 
             if not imported_name:
                 add_external_def(src_name, tgt_name)
@@ -249,8 +245,6 @@ class PreProcessor(ProcessingBase):
         for modname in self.import_manager.get_imports(self.modname):
             if self.exclusives and modname.split(".")[0] not in self.exclusives:
                 continue
-
-            print(modname)
 
             fname = self.import_manager.get_filepath(modname)
 

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -113,11 +113,11 @@ class PreProcessor(ProcessingBase):
             items = self.scope_manager.handle_module(
                 self.modname, self.filename, self.contents
             )
+            print('pre items', items)
             items = [
                 i for i in items if not \
                     any(ignored_mod in i for ignored_mod in self.ignored_mods)
             ]
-            print('pre items', items)
 
             root_sc = self.scope_manager.get_scope(self.modname)
             root_defi = self.def_manager.get(self.modname)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -87,14 +87,10 @@ class PreProcessor(ProcessingBase):
 
     def visit_Module(self, node):
         def iterate_mod_items(items, const):
-            print('iter items', [
+            print('bad iter items', [
                 i for i in items if \
                     any(ignored_mod in i for ignored_mod in self.ignored_mods)
             ])
-            items = [
-                i for i in items if not \
-                    any(ignored_mod in i for ignored_mod in self.ignored_mods)
-            ]
             for item in items:
                 defi = self.def_manager.get(item)
                 if not defi:
@@ -105,9 +101,12 @@ class PreProcessor(ProcessingBase):
                 parentns = ".".join(splitted[:-1])
                 self.scope_manager.get_scope(parentns).add_def(name, defi)
 
+        if "test_" in self.filename:
+            print('skip', self.filename)
+            return
+
         print('modname', self.modname, self.filename)
         self.import_manager.set_current_mod(self.modname, self.filename)
-        print('modname', self.modname, self.filename)
 
         mod = self.module_manager.create(self.modname, self.filename)
 

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -30,6 +30,8 @@ class PreProcessor(ProcessingBase):
         self,
         filename,
         modname,
+        exclusives,
+        ignored_mods,
         import_manager,
         scope_manager,
         def_manager,
@@ -40,6 +42,8 @@ class PreProcessor(ProcessingBase):
         super().__init__(filename, modname, modules_analyzed)
 
         self.modname = modname
+        self.exclusives = exclusives
+        self.ignored_mods = ignored_mods
         self.mod_dir = "/".join(self.filename.split("/")[:-1])
 
         self.import_manager = import_manager
@@ -71,6 +75,8 @@ class PreProcessor(ProcessingBase):
         super().analyze_submodule(
             PreProcessor,
             modname,
+            self.exclusives,
+            self.ignored_mods,
             self.import_manager,
             self.scope_manager,
             self.def_manager,
@@ -204,6 +210,14 @@ class PreProcessor(ProcessingBase):
             src_name = handle_src_name(import_item.name)
             tgt_name = import_item.asname if import_item.asname else import_item.name
             imported_name = self.import_manager.handle_import(src_name, level)
+            
+            # Limit to exclusive module            
+            if src_name.split(".")[0] not in self.exclusives:
+                continue
+
+            # Skip ignored modules            
+            if tgt_name in self.ignored_mods:
+                continue
 
             if not imported_name:
                 add_external_def(src_name, tgt_name)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -120,7 +120,12 @@ class PreProcessor(ProcessingBase):
             items = self.scope_manager.handle_module(
                 self.modname, self.filename, self.contents
             )
-            print('items', items)
+            bad_items = [
+                i for i in items if \
+                    any(ignored_mod in i for ignored_mod in self.ignored_mods)
+            ]
+            if len(bad_items)>0:
+                print('bad_items', bad_items)
 
             root_sc = self.scope_manager.get_scope(self.modname)
             root_defi = self.def_manager.get(self.modname)
@@ -214,7 +219,7 @@ class PreProcessor(ProcessingBase):
                 tgt_defi.get_name_pointer().add(defi.get_ns())
                 scope.add_def(target, tgt_defi)
 
-        print(node.names, self.modname)
+        print([*node.names], self.modname)
 
         for import_item in node.names:
             src_name = handle_src_name(import_item.name)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -87,13 +87,11 @@ class PreProcessor(ProcessingBase):
 
     def visit_Module(self, node):
         def iterate_mod_items(items, const):
-            bad_items = [
+            items = [
                 i for i in items if \
-                    any(ignored_mod in i for ignored_mod in self.ignored_mods)
+                    not any(ignored_mod in i for ignored_mod in self.ignored_mods)
             ]
-            if len(bad_items) > 0:
-                print('bad iter items', bad_items)
-
+            
             for item in items:
                 defi = self.def_manager.get(item)
                 if not defi:
@@ -120,12 +118,6 @@ class PreProcessor(ProcessingBase):
             items = self.scope_manager.handle_module(
                 self.modname, self.filename, self.contents
             )
-            bad_items = [
-                i for i in items if \
-                    any(ignored_mod in i for ignored_mod in self.ignored_mods)
-            ]
-            if len(bad_items)>0:
-                print('bad_items', bad_items)
 
             root_sc = self.scope_manager.get_scope(self.modname)
             root_defi = self.def_manager.get(self.modname)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -91,7 +91,6 @@ class PreProcessor(ProcessingBase):
                 i for i in items if not \
                     any(ignored_mod in i for ignored_mod in self.ignored_mods)
             ]
-            print('items',items)
             for item in items:
                 defi = self.def_manager.get(item)
                 if not defi:

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -109,8 +109,6 @@ class PreProcessor(ProcessingBase):
 
         mod = self.module_manager.create(self.modname, self.filename)
 
-        print('visit_mod', self.modname,self.filename)
-
         first = 1
         last = len(self.contents.splitlines())
         if last == 0:
@@ -226,7 +224,6 @@ class PreProcessor(ProcessingBase):
 
             # Skip ignored modules
             if tgt_name in self.ignored_mods:
-                print('skip',tgt_name)
                 continue
 
             imported_name = self.import_manager.handle_import(src_name, level)
@@ -251,8 +248,6 @@ class PreProcessor(ProcessingBase):
         for modname in self.import_manager.get_imports(self.modname):
             if self.exclusives and modname.split(".")[0] not in self.exclusives:
                 continue
-
-            print(modname)
 
             fname = self.import_manager.get_filepath(modname)
 
@@ -433,9 +428,7 @@ class PreProcessor(ProcessingBase):
 
     def visit_ClassDef(self, node):
         # create a definition for the class (node.name)
-        print('pre class', node.name)
         if node.name in self.ignored_mods:
-            print('skip')
             return
 
         cls_def = self.def_manager.handle_class_def(self.current_ns, node.name)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -87,6 +87,10 @@ class PreProcessor(ProcessingBase):
 
     def visit_Module(self, node):
         def iterate_mod_items(items, const):
+            print('iter items', items = [
+                i for i in items if \
+                    any(ignored_mod in i for ignored_mod in self.ignored_mods)
+            ])
             items = [
                 i for i in items if not \
                     any(ignored_mod in i for ignored_mod in self.ignored_mods)
@@ -117,6 +121,7 @@ class PreProcessor(ProcessingBase):
             items = self.scope_manager.handle_module(
                 self.modname, self.filename, self.contents
             )
+            print('items', items)
 
             root_sc = self.scope_manager.get_scope(self.modname)
             root_defi = self.def_manager.get(self.modname)

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -206,7 +206,6 @@ class PreProcessor(ProcessingBase):
                 tgt_defi.get_name_pointer().add(defi.get_ns())
                 scope.add_def(target, tgt_defi)
 
-        print('node', node)
         for import_item in node.names:
             src_name = handle_src_name(import_item.name)
             tgt_name = import_item.asname if import_item.asname else import_item.name
@@ -240,8 +239,7 @@ class PreProcessor(ProcessingBase):
         for modname in self.import_manager.get_imports(self.modname):
             if modname.split(".")[0] not in self.exclusives:
                 continue
-            
-            print('mod', modname)
+
             fname = self.import_manager.get_filepath(modname)
 
             if not fname:

--- a/pycg/processing/preprocessor.py
+++ b/pycg/processing/preprocessor.py
@@ -87,6 +87,11 @@ class PreProcessor(ProcessingBase):
 
     def visit_Module(self, node):
         def iterate_mod_items(items, const):
+            items = [
+                i for i in items if not \
+                    any(ignored_mod in i for ignored_mod in self.ignored_mods)
+            ]
+
             for item in items:
                 defi = self.def_manager.get(item)
                 if not defi:
@@ -113,11 +118,6 @@ class PreProcessor(ProcessingBase):
             items = self.scope_manager.handle_module(
                 self.modname, self.filename, self.contents
             )
-            print('pre items', items)
-            items = [
-                i for i in items if not \
-                    any(ignored_mod in i for ignored_mod in self.ignored_mods)
-            ]
 
             root_sc = self.scope_manager.get_scope(self.modname)
             root_defi = self.def_manager.get(self.modname)

--- a/pycg/pycg.py
+++ b/pycg/pycg.py
@@ -141,7 +141,7 @@ class CallGraphGenerator(object):
 
             if not input_pkg:
                 input_pkg = os.path.dirname(input_file)
-
+            print(input_pkg)
             if input_mod not in modules_analyzed:
                 if install_hooks:
                     self.import_manager.set_pkg(input_pkg)

--- a/pycg/pycg.py
+++ b/pycg/pycg.py
@@ -139,9 +139,14 @@ class CallGraphGenerator(object):
             if not input_mod:
                 continue
 
+            print(input_pkg, input_file)
+
+            if "test_" in input_file:
+                print('skip!')
+                continue
+
             if not input_pkg:
                 input_pkg = os.path.dirname(input_file)
-            print(input_pkg)
             if input_mod not in modules_analyzed:
                 if install_hooks:
                     self.import_manager.set_pkg(input_pkg)

--- a/pycg/pycg.py
+++ b/pycg/pycg.py
@@ -35,9 +35,11 @@ from pycg.processing.preprocessor import PreProcessor
 
 
 class CallGraphGenerator(object):
-    def __init__(self, entry_points, package, max_iter, operation):
+    def __init__(self, entry_points, package, exclusives, ignored_mods, max_iter, operation):
         self.entry_points = entry_points
         self.package = package
+        self.exclusives = exclusives
+        self.ignored_mods = ignored_mods
         self.state = None
         self.max_iter = max_iter
         self.operation = operation
@@ -162,6 +164,8 @@ class CallGraphGenerator(object):
         self.do_pass(
             PreProcessor,
             True,
+            self.exclusives,
+            self.ignored_mods,
             self.import_manager,
             self.scope_manager,
             self.def_manager,
@@ -179,6 +183,8 @@ class CallGraphGenerator(object):
             self.do_pass(
                 PostProcessor,
                 False,
+                self.exclusives,
+                self.ignored_mods,
                 self.import_manager,
                 self.scope_manager,
                 self.def_manager,

--- a/pycg/pycg.py
+++ b/pycg/pycg.py
@@ -139,12 +139,6 @@ class CallGraphGenerator(object):
             if not input_mod:
                 continue
 
-            print(input_pkg, input_file)
-
-            if "test_" in input_file:
-                print('skip!')
-                continue
-
             if not input_pkg:
                 input_pkg = os.path.dirname(input_file)
             if input_mod not in modules_analyzed:

--- a/pycg/pycg.py
+++ b/pycg/pycg.py
@@ -141,6 +141,7 @@ class CallGraphGenerator(object):
 
             if not input_pkg:
                 input_pkg = os.path.dirname(input_file)
+
             if input_mod not in modules_analyzed:
                 if install_hooks:
                     self.import_manager.set_pkg(input_pkg)

--- a/pycg/pycg.py
+++ b/pycg/pycg.py
@@ -36,12 +36,12 @@ from pycg.processing.preprocessor import PreProcessor
 
 class CallGraphGenerator(object):
     def __init__(
-        self, entry_points, package, exclusives, ignored_mods, max_iter, operation
+        self, entry_points, package, exclusives, skip_classes, max_iter, operation
     ):
         self.entry_points = entry_points
         self.package = package
         self.exclusives = exclusives
-        self.ignored_mods = ignored_mods
+        self.skip_classes = skip_classes
         self.state = None
         self.max_iter = max_iter
         self.operation = operation
@@ -167,7 +167,7 @@ class CallGraphGenerator(object):
             PreProcessor,
             True,
             self.exclusives,
-            self.ignored_mods,
+            self.skip_classes,
             self.import_manager,
             self.scope_manager,
             self.def_manager,
@@ -186,7 +186,7 @@ class CallGraphGenerator(object):
                 PostProcessor,
                 False,
                 self.exclusives,
-                self.ignored_mods,
+                self.skip_classes,
                 self.import_manager,
                 self.scope_manager,
                 self.def_manager,

--- a/pycg/pycg.py
+++ b/pycg/pycg.py
@@ -35,7 +35,9 @@ from pycg.processing.preprocessor import PreProcessor
 
 
 class CallGraphGenerator(object):
-    def __init__(self, entry_points, package, exclusives, ignored_mods, max_iter, operation):
+    def __init__(
+        self, entry_points, package, exclusives, ignored_mods, max_iter, operation
+    ):
         self.entry_points = entry_points
         self.package = package
         self.exclusives = exclusives


### PR DESCRIPTION
This way we can pass in `["pwdata"]` as a exclusive package to filter by and then skip all the Pipeline classes as `ignored_mods`.